### PR TITLE
test image for airflow

### DIFF
--- a/airflow_test/Dockerfile
+++ b/airflow_test/Dockerfile
@@ -1,0 +1,5 @@
+FROM fathomhealth/docker-airflow
+
+COPY requirements.txt /usr/src
+
+RUN pip install --no-cache-dir -r requirements.txt

--- a/airflow_test/Dockerfile
+++ b/airflow_test/Dockerfile
@@ -2,4 +2,4 @@ FROM fathomhealth/docker-airflow
 
 COPY requirements.txt /usr/local/airflow
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN sudo pip3 install --no-cache-dir -r requirements.txt

--- a/airflow_test/Dockerfile
+++ b/airflow_test/Dockerfile
@@ -3,3 +3,5 @@ FROM fathomhealth/docker-airflow
 COPY requirements.txt /usr/local/airflow
 
 RUN sudo pip3 install --no-cache-dir -r requirements.txt
+
+ENV PYTHONPATH=:/usr/src/app/diseaseTools

--- a/airflow_test/Dockerfile
+++ b/airflow_test/Dockerfile
@@ -1,7 +1,9 @@
 FROM fathomhealth/docker-airflow
 
 COPY requirements.txt /usr/local/airflow
+COPY test_entrypoint.sh /test_entrypoint.sh
 
 RUN sudo pip3 install --no-cache-dir -r requirements.txt
 
 ENV PYTHONPATH=:/usr/src/app/diseaseTools
+ENTRYPOINT ["/test_entrypoint.sh"]

--- a/airflow_test/Dockerfile
+++ b/airflow_test/Dockerfile
@@ -1,5 +1,5 @@
 FROM fathomhealth/docker-airflow
 
-COPY requirements.txt /usr/src
+COPY requirements.txt /usr/local/airflow
 
 RUN pip install --no-cache-dir -r requirements.txt

--- a/airflow_test/requirements.txt
+++ b/airflow_test/requirements.txt
@@ -1,0 +1,8 @@
+pyyaml==3.12
+invoke==0.14.0
+tensorflow==1.0.0
+nltk==3.2.1
+sqlalchemy==1.1.2
+pytest==3.0.3
+pytest-mock==1.5.0
+mock==2.0.0

--- a/airflow_test/test_entrypoint.sh
+++ b/airflow_test/test_entrypoint.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+AIRFLOW_HOME="/usr/local/airflow"
+CMD="airflow"
+TRY_LOOP="10"
+POSTGRES_HOST="postgres"
+POSTGRES_PORT="5432"
+RABBITMQ_HOST="rabbitmq"
+RABBITMQ_CREDS="airflow:airflow"
+: ${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print FERNET_KEY")}
+# FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print FERNET_KEY")
+
+# Load DAGs exemples (default: Yes)
+if [ "x$LOAD_EX" = "xn" ]; then
+    sed -i "s/load_examples = True/load_examples = False/" "$AIRFLOW_HOME"/airflow.cfg
+fi
+
+# Install custome python package if requirements.txt is present
+if [ -e "/requirements.txt" ]; then
+    $(which pip) install --user -r /requirements.txt
+fi
+
+# Give access to /var/run/docker.sock to aiflow user (its not always there)
+sudo chown airflow:airflow /var/run/docker.sock | true
+
+# Generate Fernet key
+sed -i "s|\$FERNET_KEY|$FERNET_KEY|" "$AIRFLOW_HOME"/airflow.cfg
+
+if [ "$1" = "version" ]; then
+  exec $CMD version
+fi
+
+sed -i "s#sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@postgres/airflow#sql_alchemy_conn = sqlite:////usr/local/airflow/airflow.db#" "$AIRFLOW_HOME"/airflow.cfg
+echo "Initialize database..."
+$CMD initdb
+echo "Database initialized!"
+
+python3 -m pytest ./tests

--- a/airflow_test/test_entrypoint.sh
+++ b/airflow_test/test_entrypoint.sh
@@ -30,6 +30,7 @@ if [ "$1" = "version" ]; then
   exec $CMD version
 fi
 
+sed -i "s/executor = CeleryExecutor/executor = SequentialExecutor/" "$AIRFLOW_HOME"/airflow.cfg
 sed -i "s#sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@postgres/airflow#sql_alchemy_conn = sqlite:////usr/local/airflow/airflow.db#" "$AIRFLOW_HOME"/airflow.cfg
 echo "Initialize database..."
 $CMD initdb


### PR DESCRIPTION
To have circleci run pytest on dags in a dedicated image, we need to install pytest and utils dependencies on the test tag of that image.
1) Dockerfile that pulls from existing docker-airflow image
2) installs from requirements.txt for pytest