### PR TITLE
Add bs4 to main image, remove redundant include in :test image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex \
        ubuntu-xenial \
        main" \
     && sudo apt-get update \
-    && sudo apt-get -y install docker-engine nvidia-modprobe \ 
+    && sudo apt-get -y install docker-engine nvidia-modprobe \
     && wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1-1_amd64.deb \
     && sudo dpkg -i /tmp/nvidia-docker*.deb \
     && pip3 install --upgrade pip \
@@ -91,6 +91,7 @@ RUN set -ex \
     && pip3 install https://github.com/docker/docker-py/archive/1.10.6.zip \
     && pip3 install apache-airflow[celery,postgres,hive,hdfs,jdbc]==$AIRFLOW_VERSION \
     && pip3 install https://github.com/medicode/incubator-airflow/archive/v1-8-test.zip \
+    && pip3 install beautifulsoup4==4.6.0 \
     && apt-get remove --purge -yqq $buildDeps libpq-dev \
     && apt-get clean \
     && rm -rf \

--- a/airflow_test/requirements.txt
+++ b/airflow_test/requirements.txt
@@ -8,4 +8,3 @@ pytest-mock==1.5.0
 mock==2.0.0
 git+git://github.com/google/python-fire.git@v0.1.1
 defusedxml==0.4.1
-beautifulsoup4==4.6.0


### PR DESCRIPTION
Add bs4 to main image and remove redundant mention from :test image.

This is needed for using diseaseTools/ utils/utils.py inside of airflow_utils.py to use Randall's modify_yaml function. (Used for overriding yaml in generating test versions of existing dags--not yet checked in)

cbockman@ FYI