### PR TITLE
Feature/1 9 official

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Airflow
-ARG AIRFLOW_VERSION=1.8.1
+ARG AIRFLOW_VERSION=1.9.0
 ENV AIRFLOW_HOME /usr/local/airflow
 
 # Define en_US.
@@ -24,7 +24,7 @@ ENV LC_ALL en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
 ENV LC_MESSAGES en_US.UTF-8
 ENV LC_ALL  en_US.UTF-8
-ENV PYTHONPATH=:/usr/local/airflow/dags
+ENV PYTHONPATH=:/usr/local/airflow/dags:/usr/local/airflow/config
 
 RUN set -ex \
     && buildDeps=' \
@@ -89,8 +89,7 @@ RUN set -ex \
     && pip3 install celery==4.1.0 \
     && pip3 install kubernetes \
     && pip3 install https://github.com/docker/docker-py/archive/1.10.6.zip \
-    && pip3 install apache-airflow[celery,postgres,hive,hdfs,jdbc]==$AIRFLOW_VERSION \
-    && pip3 install https://github.com/medicode/incubator-airflow/archive/v1-8-test.zip \
+    && pip3 install apache-airflow[celery,postgres,hive,hdfs,jdbc,gcp_api]==$AIRFLOW_VERSION \
     && apt-get remove --purge -yqq $buildDeps libpq-dev \
     && apt-get clean \
     && rm -rf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,12 @@ RUN set -ex \
     && pip3 install celery==4.1.0 \
     && pip3 install kubernetes \
     && pip3 install https://github.com/docker/docker-py/archive/1.10.6.zip \
-    && pip3 install apache-airflow[celery,postgres,hive,hdfs,jdbc,gcp_api]==$AIRFLOW_VERSION \
+    && pip3 install apache-airflow[celery,postgres,hive,hdfs,jdbc]==$AIRFLOW_VERSION \
+    && pip3 install httplib2 \
+    && pip3 install "google-api-python-client>=1.5.0,<1.6.0" \
+    && pip3 install "PyOpenSSL" \
+    && pip3 install "oauth2client>=2.0.2,<2.1.0" \
+    && pip3 install pandas-gbq \
     && apt-get remove --purge -yqq $buildDeps libpq-dev \
     && apt-get clean \
     && rm -rf \

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -42,6 +42,7 @@ if [ "$1" = "webserver" ] || [ "$1" = "worker" ] || [ "$1" = "scheduler" ] ; the
   if [ "$1" = "webserver" ]; then
     echo "Initialize database..."
     $CMD initdb
+    $CMD connections --add --conn_id gcs --conn_type google_cloud_platorm --conn_extra '{"extra__google_cloud_platform__key_path":"/usr/local/airflow/secrets/gcs_key.json", "extra__google_cloud_platform__project": "fathom-containers", "extra__google_cloud_platform__scope": "https://www.googleapis.com/auth/cloud-platform"}'
   fi
   sleep 5
 fi


### PR DESCRIPTION
Updates base image to v1.9

Note some additional dependencies were inlined from:
https://github.com/apache/incubator-airflow/blob/v1-9-stable/setup.py#L129

Because specifying pip3 install apache-airflow[...,gcp_api,..] causes the installation of apache-beam through the cloud-dataflow dependency, and apache-beam doesn't build in python3

TESTED:
airbender instance
azure docker-compose airflow instance
  