### PR TITLE
Changes for running airflow colocated in a single pod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN pip3 install --upgrade pip \
     && pip3 install pyasn1 \
     && pip3 install psycopg2 \
     && pip3 install pandas==0.18.1 \
-    && pip3 install celery==4.1.0 \
+    && pip3 install celery==4.1.1 \
     && pip3 install kubernetes \
     && pip3 install https://github.com/docker/docker-py/archive/1.10.6.zip \
     && pip3 install apache-airflow[celery,postgres,hive,hdfs,jdbc]==$AIRFLOW_VERSION \

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -3,9 +3,9 @@
 AIRFLOW_HOME="/usr/local/airflow"
 CMD="airflow"
 TRY_LOOP="10"
-POSTGRES_HOST="airflow"
+POSTGRES_HOST="${POSTGRES_HOST:-postgres}"
 POSTGRES_PORT="5432"
-RABBITMQ_HOST="airflow"
+RABBITMQ_HOST="${RABBITMQ_HOST:-rabbitmq}"
 RABBITMQ_CREDS="airflow:airflow"
 : ${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print FERNET_KEY")}
 # FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print FERNET_KEY")
@@ -73,7 +73,7 @@ else
     exec $CMD version
   fi
   sed -i "s/executor = CeleryExecutor/executor = SequentialExecutor/" "$AIRFLOW_HOME"/airflow.cfg
-  sed -i "s#sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@airflow/airflow#sql_alchemy_conn = sqlite:////usr/local/airflow/airflow.db#" "$AIRFLOW_HOME"/airflow.cfg
+  sed -i "s#sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@${POSTGRES_HOST}/airflow#sql_alchemy_conn = sqlite:////usr/local/airflow/airflow.db#" "$AIRFLOW_HOME"/airflow.cfg
   echo "Initialize database..."
   $CMD initdb
   exec $CMD webserver

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -3,9 +3,9 @@
 AIRFLOW_HOME="/usr/local/airflow"
 CMD="airflow"
 TRY_LOOP="10"
-POSTGRES_HOST="postgres"
+POSTGRES_HOST="airflow"
 POSTGRES_PORT="5432"
-RABBITMQ_HOST="rabbitmq"
+RABBITMQ_HOST="airflow"
 RABBITMQ_CREDS="airflow:airflow"
 : ${FERNET_KEY:=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print FERNET_KEY")}
 # FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print FERNET_KEY")

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -73,7 +73,7 @@ else
     exec $CMD version
   fi
   sed -i "s/executor = CeleryExecutor/executor = SequentialExecutor/" "$AIRFLOW_HOME"/airflow.cfg
-  sed -i "s#sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@postgres/airflow#sql_alchemy_conn = sqlite:////usr/local/airflow/airflow.db#" "$AIRFLOW_HOME"/airflow.cfg
+  sed -i "s#sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@airflow/airflow#sql_alchemy_conn = sqlite:////usr/local/airflow/airflow.db#" "$AIRFLOW_HOME"/airflow.cfg
   echo "Initialize database..."
   $CMD initdb
   exec $CMD webserver


### PR DESCRIPTION
- use env vars for postgres and rabbitmq host so that we can change where they live in airbender, local docker compose etc.
- update celery after encountering a bug. Suggested by https://github.com/celery/kombu/issues/870 possible some unfrozen requirement shifted after rebuilding the docker image

Tested:
- cmc debug
- ingress mode 
- load balancer mode

accompanying https://github.com/medicode/kube-config/pull/99 and https://github.com/medicode/diseaseTools/pull/2562
