### PR TITLE
Add python-fire to airflow test image

### DIFF
--- a/airflow_test/requirements.txt
+++ b/airflow_test/requirements.txt
@@ -1,1 +1,5 @@
 pytest==3.8.2
+# for test_airflow_utils which invokes a fire file to test it
+# TODO: find a way to test without this or invoke in test how it
+# actually gets invoked in production code (via Docker)
+git+git://github.com/google/python-fire.git@v0.1.1


### PR DESCRIPTION
This is needed for [`test_airflow_utils.py`](https://github.com/medicode/diseaseTools/blob/48faa918283978e44c239a974348da575ad422ce/tests/test_airflow_utils.py#L46) which I'm moving to `fathomairflow/...` and thus will get run by the airflow test image.