### PR TITLE
update gcr.io references to use us.gcr.io instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # BUILD: docker build --rm -t puckel/docker-airflow .
 # SOURCE: https://github.com/puckel/docker-airflow
 
-FROM gcr.io/fathom-containers/debian-python3
+FROM us.gcr.io/fathom-containers/debian-python3
 LABEL maintainer="Puckel_"
 
 # Never prompts the user for choices on installation/configuration of packages

--- a/airflow_test/Dockerfile
+++ b/airflow_test/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/fathom-containers/docker-airflow
+FROM us.gcr.io/fathom-containers/docker-airflow
 USER root
 COPY requirements.txt /usr/local/airflow
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
**ASANA TASK LINK:** https://app.asana.com/0/1140153117941490/1155931194339842/f

**DESIGN DOC LINK:** https://docs.google.com/document/d/1gox2x_WggIn4cUNirgjQdrmYehd-x6QMc6eE8EsZkH0/edit?folder=0B428sZA2e4WmdmxlSXNOSHozc2M#

**Rationale**
once images are built in the us registry (us.gcr.io) we'll merge this to fetch from there instead of gcr.io
