### PR TITLE
Forcing an older version of redis for compatability reasons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN set -ex \
     && pip install pyasn1 \
     && pip install marshmallow-sqlalchemy==0.17.0 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,gcp_api]==$AIRFLOW_VERSION \
+    && pip install redis==3.3.11 \
     && pip install 'celery[redis]>=4.1.1,<4.2.0' \
     && pip install 'tornado<6.0.0' \
     && apt-get purge --auto-remove -yqq $buildDeps \


### PR DESCRIPTION
Forcing our docker image to install Redis with version 3.3.11 instead of the newest version. The recent Redis update is causing issues for our airflow instances and should be dealt with later. Installing this version of Redis before the celery bundle will force a version (since celery bundles appear not to support requirement version specification).