### PR TITLE
only build images in us.gcr.io registry

### DIFF
--- a/cloud_builder.yaml
+++ b/cloud_builder.yaml
@@ -2,44 +2,19 @@ timeout: 3600s
 steps:
 - id: common
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "gcr.io/$PROJECT_ID/docker-airflow:latest", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow:latest", "."]
   dir: .
   waitFor: ['-']
 
 - id: airflow-test
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "gcr.io/$PROJECT_ID/docker-airflow-test:latest", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-test:latest", "."]
   dir: airflow_test/
   waitFor:
     - common
-
-- id: us-common
-  name: 'gcr.io/cloud-builders/docker'
-  args: [
-    "build",
-    "-t", "us.gcr.io/$PROJECT_ID/docker-airflow:latest",
-    "--cache-from", "gcr.io/$PROJECT_ID/docker-airflow:latest",
-    "."]
-  dir: .
-  waitFor:
-    - common
-
-- id: us-airflow-test
-  name: 'gcr.io/cloud-builders/docker'
-  args: [
-    "build",
-    "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-test:latest",
-    "--cache-from", "gcr.io/$PROJECT_ID/docker-airflow-test:latest",
-    "."]
-  dir: airflow_test/
-  waitFor:
-    - airflow-test
-    - us-common
 
 logsBucket: fathom-containers-cloud-build-logs-36tugmiz
 
 images:
-  - gcr.io/$PROJECT_ID/docker-airflow
-  - gcr.io/$PROJECT_ID/docker-airflow-test
   - us.gcr.io/$PROJECT_ID/docker-airflow
   - us.gcr.io/$PROJECT_ID/docker-airflow-test


### PR DESCRIPTION
**ASANA TASK LINK:** https://app.asana.com/0/1140153117941490/1155931194339842/f

**DESIGN DOC LINK:** https://docs.google.com/document/d/1gox2x_WggIn4cUNirgjQdrmYehd-x6QMc6eE8EsZkH0/edit?folder=0B428sZA2e4WmdmxlSXNOSHozc2M#

**Rationale**
once all references to gcr.io have been flipped to us.gcr.io we will only build to the us.gcr.io registry
