### PR TITLE
Revert airflow to v1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -yqq \
     && unattended-upgrade -v
 
 # Airflow
-ARG AIRFLOW_VERSION=1.10.0
+ARG AIRFLOW_VERSION=1.10.2
 ARG AIRFLOW_HOME=/usr/local/airflow
 
 # Define en_US.
@@ -75,6 +75,8 @@ RUN set -ex \
     && pip install marshmallow-sqlalchemy==0.17.0 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,gcp_api]==$AIRFLOW_VERSION \
     && pip install redis==3.3.11 \
+    && pip install psycopg2 \
+    && pip install psycopg2-binary \
     && pip install 'celery[redis]>=4.1.1,<4.2.0' \
     && pip install 'tornado<6.0.0' \
     && apt-get purge --auto-remove -yqq $buildDeps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -yqq \
     && unattended-upgrade -v
 
 # Airflow
-ARG AIRFLOW_VERSION=1.10.2
+ARG AIRFLOW_VERSION=1.10.0
 ARG AIRFLOW_HOME=/usr/local/airflow
 
 # Define en_US.
@@ -75,8 +75,6 @@ RUN set -ex \
     && pip install marshmallow-sqlalchemy==0.17.0 \
     && pip install apache-airflow[crypto,celery,postgres,hive,jdbc,mysql,gcp_api]==$AIRFLOW_VERSION \
     && pip install redis==3.3.11 \
-    && pip install psycopg2 \
-    && pip install psycopg2-binary \
     && pip install 'celery[redis]>=4.1.1,<4.2.0' \
     && pip install 'tornado<6.0.0' \
     && apt-get purge --auto-remove -yqq $buildDeps \


### PR DESCRIPTION
Revert Airflow update to v1.10.2 and delete requisite dependencies (psycopg2 and psycopg2-binary)

Asana Task: 
• https://app.asana.com/0/home/1164815434365741/1167624867518356

Design Docs:
• https://docs.google.com/document/d/1Z8jEYZ1beMtupmDDtQ3gAEfmKVvIxy-LDX2dNorMOCM/edit#
• https://docs.google.com/document/d/1d7mjNyYib230uq6q8mf_ivhc4RnG10o8fsIRe9E_qQg/edit