### PR TITLE
add diseaseTools-config mount point to docker-airflow PYTHONPATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV LC_ALL en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
 ENV LC_MESSAGES en_US.UTF-8
 ENV LC_ALL  en_US.UTF-8
-ENV PYTHONPATH=:/usr/local/airflow/dags:/usr/local/airflow/config
+ENV PYTHONPATH=:/usr/local/airflow/dags:/usr/local/airflow/config:/usr/src/config
 # To prevent Airflow from installing a GPL
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 


### PR DESCRIPTION
Combined with medicode/kube-config/pull/262, this will allow new airbenders to use the modules defined in diseaseTools-config.

Asana: https://app.asana.com/0/1142555270241225/1199120619709927/f