### PR TITLE
Add diseaseTools to PYTHONPATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV LC_ALL en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
 ENV LC_MESSAGES en_US.UTF-8
 ENV LC_ALL  en_US.UTF-8
-ENV PYTHONPATH=:/usr/local/airflow/dags:/usr/local/airflow/config:/usr/src/config
+ENV PYTHONPATH=:/usr/local/airflow/dags:/usr/local/airflow/config:/usr/src/config:/usr/src/diseaseTools
 # To prevent Airflow from installing a GPL
 ENV SLUGIFY_USES_TEXT_UNIDECODE=yes
 


### PR DESCRIPTION
Testing making diseaseTools generally importable from `fathomairflow/` to avoid all the jankiness of needing to move shared code under `fathomairflow/`
