### PR TITLE
change to db init command

### DIFF
--- a/airflow_bridge/entrypoint.sh
+++ b/airflow_bridge/entrypoint.sh
@@ -71,7 +71,7 @@ fi
 
 case "$1" in
   webserver)
-    airflow initdb
+    airflow db init
     airflow connections --add --conn_id gcs --conn_type google_cloud_platorm --conn_extra "{\"extra__google_cloud_platform__key_path\":\"/usr/local/airflow/gcloud-secrets/$GCP_SERVICE_ACCOUNT.json\", \"extra__google_cloud_platform__project\": \"$GCP_PROJECT\", \"extra__google_cloud_platform__scope\": \"https://www.googleapis.com/auth/cloud-platform\"}"
     if [ "$AIRFLOW__CORE__EXECUTOR" = "LocalExecutor" ]; then
       # With the "Local" executor it should all run in one container.


### PR DESCRIPTION
**ASANA TASK LINK:**
https://app.asana.com/0/1161490319474002/1200750766884495/f

**DESIGN DOC LINK:**
https://docs.google.com/document/d/1iNn6NI9gBJTaAPKI5sxR_iUHxvNzgcZtE5wR33Yd5ow/edit#heading=h.p44gzhxlex9t

DETAILS
-------
Add "db init" command to entrypoint.sh (rather than initdb) 


CHECK LIST
----------
**BEST PRACTICES:**

  - [x] I did my best to follow [Fathom PR Best Practices](https://docs.google.com/document/d/1d7FBIRyDmgTvlpBBBdYtiP1IOm0s5cvP0Sae3l2dMzU/edit)
  - [x] I did my best to follow [Fathom Style Guide & Best Design Practices](https://docs.google.com/document/d/15Bc31w96t-KudUw_qw6zsiabFpEDVAXTtXNdD3PR0_g/edit#heading=h.lica5qr8yb37)
  - [ ] If I led the design, I did my best to follow [Fathom Design Document Design Practices](https://docs.google.com/document/d/11xgD11LRRsF5hPzmyvZIxymk4HbfNVs3-ckxw_DeMuw/edit#)
  - [x] If I *didn't* lead the design, I think the associated design document *does* follow Fathom Design Document Design Practices.  (Why? If you don't, then there is a good chance that the wrong thing might be coded up.)

**SUFFICIENT LOGGING?**
Refer to [When should I log?](https://docs.google.com/document/d/1lNph_Yea5XUMyFbCZK9XPh3Sn_1aaw4_8DWCkAZYENo/edit#heading=h.n40pw382u0yi)

  - [ ] I, the reviewer, thought about logging in all possible instances
  - [x] I, the coder, added logging in all possible instances

**TEST PLAN:**
You and your reviewer should have confidence that this PR (probably!) works as advertised.

- [ ] Best: "New tests covering XYZ cases"
- [ ] Sometimes: "Run dag and manually verify blah", etc.
- [ ] Occasionally: "Best guess is this fixes the issue." <-- at least be honest!

If I added or modified a coding rule, I:
- [ ] Will merge in latest develop and run LC canary tests prior to merging.
- [ ] And I did one of the following: 
  - [ ] Added or modified corresponding test cases for the [Legality Checker Canary tests DAG](https://docs.google.com/document/d/1O_70FrYERrURrkUVFvheva1WmkI9fS8SorkDtrJkp8M/edit#).
  - [ ] Believe the test coverage is sufficient.

**CHANGES TO DAG TOPOLOGY?**
N

If yes, this PR changes a production DAG's topology (adding/removing services or changing inputs or outputs) and I am responsible for coordinating with `@datacop-lead` to land the changes to master to prevent running production DAGs from falling into undefined state.

*Before merging* I have:
- [ ] informed `@buildcop-lead` and `@datacop-lead` of the changes on [#eng-datacop](https://medicode.slack.com/archives/CTV6FGCG3), with a description of my changes and a link to this PR
- [ ] waited for `@datacop-lead`'s explicit approval to merge, in coordination with `@buildcop-lead`

**DID I MATERIALLY UPDATE DOCKERFILE(S)?:**
N
- [ ] If yes, review the [image vulnerability scanner results](https://cloud.google.com/container-registry/docs/get-image-vulnerabilities) after merge, to confirm no new meaningful issues created.

**ANY KNOWN IMPACT TO 3rd PARTY (CUSTOMERS, VENDORS, PARTNERS, etc.) integrations or SLAs?:**
N

**RISK & IMPACT ASSESSMENT:**
If you know this creates risk around performance, maintainability, and/or security, please highlight here.

Most changes PRs will simply be "minimal", but, for example, if you are standing up a new web service which has external network exposure, please highlight this as a risk.

Or if you are changing a major subsystem/interface that is hard to test a priori (e.g., a GDM deployment or Airflow DAG change), please highlight.