### PR TITLE
migrate latest->debian9, debian10->latest

### DIFF
--- a/cloud_builder.yaml
+++ b/cloud_builder.yaml
@@ -2,26 +2,26 @@ timeout: 3600s
 steps:
 - id: airflow-bridge
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-bridge:latest", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-bridge:debian9", "."]
   dir: airflow_bridge/
   waitFor: ['-']
 
 - id: airflow-bridge-test
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-bridge-test:latest", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-bridge-test:debian9", "."]
   dir: airflow_bridge_test/
   waitFor:
     - airflow-bridge
 
 - id: airflow-two
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two:latest", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two:debian9", "."]
   dir: airflow_two/
   waitFor: ['-']
 
 - id: airflow-two-test
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-test:latest", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-test:debian9", "."]
   dir: airflow_two_test/
   waitFor:
     - airflow-two

--- a/cloud_builder_debian10.yaml
+++ b/cloud_builder_debian10.yaml
@@ -2,26 +2,26 @@ timeout: 3600s
 steps:
 - id: airflow-bridge
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-bridge:debian10", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-bridge:debian10", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-bridge:latest", "."]
   dir: debian10/airflow_bridge/
   waitFor: ['-']
 
 - id: airflow-bridge-test
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-bridge-test:debian10", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-bridge-test:debian10",  "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-bridge-test:latest", "."]
   dir: debian10/airflow_bridge_test/
   waitFor:
     - airflow-bridge
 
 - id: airflow-two
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two:debian10", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two:debian10", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two:latest", "."]
   dir: debian10/airflow_two/
   waitFor: ['-']
 
 - id: airflow-two-test
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-test:debian10", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-test:debian10", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-test:latest", "."]
   dir: debian10/airflow_two_test/
   waitFor:
     - airflow-two


### PR DESCRIPTION
**[ASANA TASK](https://app.asana.com/0/0/1201722519698432/f)**

This PR migrates the docker image tags for all images built in top-level trigger:
* latest -> debian9
* debian10 -> latest

Note: The tags have already been migrated on GCR, this is to synchronize the builder with the actual state.

**REVERT PLAN**
* Take roles/storage.admin on fathom-containers folder
* Disable the `docker-airflow-auto-trigger-debian10` and `docker-airflow-auto-trigger` triggers in fathom-containers cloud-build
* Manually re-tag the images in GCR
    * debian9 -> latest
* Revert this PR
* Re-enable the `docker-airflow-auto-trigger-debian10` and `docker-airflow-auto-trigger` triggers in fathom-containers cloud-build