### PR TITLE
add support for multi-arch builds based on optional FROM_TAG build arg

### DIFF
--- a/airflow_two/Dockerfile
+++ b/airflow_two/Dockerfile
@@ -3,8 +3,8 @@
 # DESCRIPTION: Basic Airflow container
 # BUILD: docker build --rm -t puckel/docker-airflow .
 # SOURCE: https://github.com/puckel/docker-airflow
-
-FROM us.gcr.io/fathom-containers/debian-python3
+ARG FROM_TAG=latest
+FROM us.gcr.io/fathom-containers/debian-python3:${FROM_TAG}
 LABEL maintainer="Puckel_"
 
 # Never prompts the user for choices on installation/configuration of packages
@@ -90,7 +90,6 @@ RUN set -ex \
     && pip install pyasn1 \
     && pip install "apache-airflow[celery,postgres,apache.hive,jdbc,mysql,google,redis]==$AIRFLOW_VERSION" --constraint "${CONSTRAINT_URL}" \
     && pip install psycopg2 \
-    && pip install pandas==0.23.4 \
     && pip install kubernetes==7.0.1 \
     && pip install google-cloud-logging==1.11.0 \
     && pip install retrying==1.3.3 \

--- a/airflow_two_test/Dockerfile
+++ b/airflow_two_test/Dockerfile
@@ -1,4 +1,5 @@
-FROM us.gcr.io/fathom-containers/docker-airflow-two
+ARG FROM_TAG=latest
+FROM us.gcr.io/fathom-containers/docker-airflow-two:${FROM_TAG}
 USER root
 COPY requirements.txt /usr/local/airflow
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
* added FROM_TAG build arg to both images to pin them to specific tag, defaulting to latest
* dropped requirement on pandas==0.23.4, since https://raw.githubusercontent.com/apache/airflow/constraints-2.1.3/constraints-3.6.txt constraint URL already uses pandas==1.1.5 and we upgraded the diseaseTools to use the same version https://github.com/medicode/diseaseTools/pull/19671 