### PR TITLE
change the constraints version to 3.7

### DIFF
--- a/airflow_two/Dockerfile
+++ b/airflow_two/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update -yqq \
 
 # Airflow
 ARG AIRFLOW_VERSION=2.1.3
-ARG CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.6.txt"
+ARG CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.7.txt"
 ARG AIRFLOW_HOME=/usr/local/airflow
 
 # Define en_US.


### PR DESCRIPTION
[Fix broken docker-airflow images](https://app.asana.com/0/0/1204004649114033)

Test plan: the image built successfully locally.

Original failing job: https://app.circleci.com/pipelines/github/medicode/diseaseTools/163545/workflows/360849d5-40d7-48a0-b36d-1344d36cc4f8/jobs/849064