### PR TITLE
Move the upgrade image to 2.4.3

### DIFF
--- a/airflow_two_upgrade/Dockerfile
+++ b/airflow_two_upgrade/Dockerfile
@@ -1,4 +1,4 @@
-# VERSION 2.5.1
+# VERSION 2.4.3
 # AUTHOR: Matthieu "Puckel_" Roisil
 # DESCRIPTION: Basic Airflow container
 # BUILD: docker build --rm -t puckel/docker-airflow .
@@ -17,7 +17,7 @@ RUN apt-get update -yqq \
     && unattended-upgrade -v
 
 # Airflow
-ARG AIRFLOW_VERSION=2.5.1
+ARG AIRFLOW_VERSION=2.4.3
 ARG CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.7.txt"
 ARG AIRFLOW_HOME=/usr/local/airflow
 


### PR DESCRIPTION
asana: https://app.asana.com/0/1202006417667823/1206408662580066/f

DD: https://docs.google.com/document/d/1h9cdpUeS5pC9P_Z_ycuq4WyPbT8W0_1TjC1Z51Jidh0/edit#bookmark=id.sh3wewjivm4f

Found out there are other imports of `gcloud` with diseasetools/gcloud. We will go with highest version of airflow without any imports of `gcloud` which is 2.4.3