### PR TITLE
airflow user should own /root so that it can access gcloud creds correctly

### DIFF
--- a/airflow_two/Dockerfile
+++ b/airflow_two/Dockerfile
@@ -107,6 +107,7 @@ COPY /entrypoint.sh /entrypoint.sh
 ADD /webserver_config.py ${AIRFLOW_HOME}
 
 RUN chown -R airflow: ${AIRFLOW_HOME}
+RUN chown -R airflow: /root/
 
 EXPOSE 8080 5555 8793
 

--- a/airflow_two_upgrade/Dockerfile
+++ b/airflow_two_upgrade/Dockerfile
@@ -107,6 +107,7 @@ COPY /entrypoint.sh /entrypoint.sh
 ADD /webserver_config.py ${AIRFLOW_HOME}
 
 RUN chown -R airflow: ${AIRFLOW_HOME}
+RUN chown -R airflow: /root/
 
 EXPOSE 8080 5555 8793
 


### PR DESCRIPTION
https://app.asana.com/0/1202006417667823/1206822930927120/f

To test, I ran:
```shell
> docker build --build-arg FROM_TAG=arm .
Success, image at 8eb9478caada19fd27696790ea1353372e9f1723c9b499073f11e7ec239c3788

> dkim --entrypoint python3 -v ~/diseaseTools:/usr/src/diseaseTools -v ~/diseaseTools/fathomairflow/dags:/usr/local/airflow/dags -v ~/tensor2tensor:/usr/src/t2t -v ~/diseaseTools-config:/usr/src/config -w /usr/local/airflow/dags 8eb9478caada19fd27696790ea1353372e9f1723c9b499073f11e7ec239c3788 night/parse.py
Success
```
