### PR TITLE
Update packages that are no longer in the Debian repos

### DIFF
--- a/airflow_two/Dockerfile
+++ b/airflow_two/Dockerfile
@@ -56,22 +56,21 @@ RUN set -ex \
         default-mysql-server \
         default-libmysqlclient-dev \
         apt-utils \
-        python-dev \
         libsasl2-dev \
         gcc \
         curl \
         rsync \
         libpq5 \
-        netcat \
+        netcat-traditional \
         locales \
         git \
         freetds-bin \
         krb5-user \
         ldap-utils \
-        libffi6 \
+        libffi8 \
         libsasl2-2 \
         libsasl2-modules \
-        libssl1.1 \
+        libssl3 \
         locales  \
         lsb-release \
         sasl2-bin \

--- a/airflow_two_upgrade/Dockerfile
+++ b/airflow_two_upgrade/Dockerfile
@@ -56,22 +56,21 @@ RUN set -ex \
         default-mysql-server \
         default-libmysqlclient-dev \
         apt-utils \
-        python-dev \
         libsasl2-dev \
         gcc \
         curl \
         rsync \
         libpq5 \
-        netcat \
+        netcat-traditional \
         locales \
         git \
         freetds-bin \
         krb5-user \
         ldap-utils \
-        libffi6 \
+        libffi8 \
         libsasl2-2 \
         libsasl2-modules \
-        libssl1.1 \
+        libssl3 \
         locales  \
         lsb-release \
         sasl2-bin \

--- a/build_arm.sh
+++ b/build_arm.sh
@@ -16,6 +16,6 @@ function build_and_push() {
 }
 
 build_and_push docker-airflow-two airflow_two
-#build_and_push docker-airflow-two-test airflow_two_test
-#build_and_push docker-airflow-two-upgrade airflow_two_upgrade
-#build_and_push docker-airflow-two-upgrade-test airflow_two_upgrade_test
+build_and_push docker-airflow-two-test airflow_two_test
+build_and_push docker-airflow-two-upgrade airflow_two_upgrade
+build_and_push docker-airflow-two-upgrade-test airflow_two_upgrade_test

--- a/build_arm.sh
+++ b/build_arm.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 repository=us.gcr.io/fathom-containers
-tag=latest
+tag=arm
 
 function build_and_push() {
     image=$1

--- a/build_arm.sh
+++ b/build_arm.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 repository=us.gcr.io/fathom-containers
-tag=wojtek-test
+tag=latest
 
 function build_and_push() {
     image=$1

--- a/build_arm.sh
+++ b/build_arm.sh
@@ -3,10 +3,7 @@
 set -euxo pipefail
 
 repository=us.gcr.io/fathom-containers
-tag=arm
-
-IMAGES=(docker-airflow-two docker-airflow-two-test docker-airflow-two-upgrade docker-airflow-two-upgrade-test)
-FOLDERS=(airflow_two airflow_two_test airflow_two_upgrade airflow_two_upgrade_test)
+tag=wojtek-test
 
 function build_and_push() {
     image=$1

--- a/build_arm.sh
+++ b/build_arm.sh
@@ -16,6 +16,6 @@ function build_and_push() {
 }
 
 build_and_push docker-airflow-two airflow_two
-build_and_push docker-airflow-two-test airflow_two_test
-build_and_push docker-airflow-two-upgrade airflow_two_upgrade
-build_and_push docker-airflow-two-upgrade-test airflow_two_upgrade_test
+#build_and_push docker-airflow-two-test airflow_two_test
+#build_and_push docker-airflow-two-upgrade airflow_two_upgrade
+#build_and_push docker-airflow-two-upgrade-test airflow_two_upgrade_test

--- a/cloud_builder.yaml
+++ b/cloud_builder.yaml
@@ -1,7 +1,7 @@
 timeout: 3600s
 
 substitutions:
-  _IMAGE_TAG: "wojtek-test"
+  _IMAGE_TAG: "latest"
 
 steps:
 - id: airflow-two

--- a/cloud_builder.yaml
+++ b/cloud_builder.yaml
@@ -2,34 +2,34 @@ timeout: 3600s
 steps:
 - id: airflow-two
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two:latest", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two:wojtek-test", "."]
   dir: airflow_two/
   waitFor: ['-']
 
-- id: airflow-two-test
-  name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-test:latest", "."]
-  dir: airflow_two_test/
-  waitFor:
-    - airflow-two
-
-- id: airflow-two-upgrade
-  name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade:latest", "."]
-  dir: airflow_two_upgrade/
-  waitFor: ['-']
-
-- id: airflow-two-upgrade-test
-  name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade-test:latest", "."]
-  dir: airflow_two_upgrade_test/
-  waitFor:
-    - airflow-two-upgrade
+#- id: airflow-two-test
+#  name: 'gcr.io/cloud-builders/docker'
+#  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-test:latest", "."]
+#  dir: airflow_two_test/
+#  waitFor:
+#    - airflow-two
+#
+#- id: airflow-two-upgrade
+#  name: 'gcr.io/cloud-builders/docker'
+#  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade:latest", "."]
+#  dir: airflow_two_upgrade/
+#  waitFor: ['-']
+#
+#- id: airflow-two-upgrade-test
+#  name: 'gcr.io/cloud-builders/docker'
+#  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade-test:latest", "."]
+#  dir: airflow_two_upgrade_test/
+#  waitFor:
+#    - airflow-two-upgrade
 
 logsBucket: fathom-containers-cloud-build-logs-36tugmiz
 
 images:
   - us.gcr.io/$PROJECT_ID/docker-airflow-two
-  - us.gcr.io/$PROJECT_ID/docker-airflow-two-test
-  - us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade
-  - us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade-test
+#  - us.gcr.io/$PROJECT_ID/docker-airflow-two-test
+#  - us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade
+#  - us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade-test

--- a/cloud_builder.yaml
+++ b/cloud_builder.yaml
@@ -1,35 +1,39 @@
 timeout: 3600s
+
+substitutions:
+  _IMAGE_TAG: "wojtek-test"
+
 steps:
 - id: airflow-two
   name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two:wojtek-test", "."]
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two:${_IMAGE_TAG}", "."]
   dir: airflow_two/
   waitFor: ['-']
 
-#- id: airflow-two-test
-#  name: 'gcr.io/cloud-builders/docker'
-#  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-test:latest", "."]
-#  dir: airflow_two_test/
-#  waitFor:
-#    - airflow-two
-#
-#- id: airflow-two-upgrade
-#  name: 'gcr.io/cloud-builders/docker'
-#  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade:latest", "."]
-#  dir: airflow_two_upgrade/
-#  waitFor: ['-']
-#
-#- id: airflow-two-upgrade-test
-#  name: 'gcr.io/cloud-builders/docker'
-#  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade-test:latest", "."]
-#  dir: airflow_two_upgrade_test/
-#  waitFor:
-#    - airflow-two-upgrade
+- id: airflow-two-test
+  name: 'gcr.io/cloud-builders/docker'
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-test:${_IMAGE_TAG}", "."]
+  dir: airflow_two_test/
+  waitFor:
+    - airflow-two
+
+- id: airflow-two-upgrade
+  name: 'gcr.io/cloud-builders/docker'
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade:${_IMAGE_TAG}", "."]
+  dir: airflow_two_upgrade/
+  waitFor: ['-']
+
+- id: airflow-two-upgrade-test
+  name: 'gcr.io/cloud-builders/docker'
+  args: ["build", "-t", "us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade-test:${_IMAGE_TAG}", "."]
+  dir: airflow_two_upgrade_test/
+  waitFor:
+    - airflow-two-upgrade
 
 logsBucket: fathom-containers-cloud-build-logs-36tugmiz
 
 images:
-  - us.gcr.io/$PROJECT_ID/docker-airflow-two
-#  - us.gcr.io/$PROJECT_ID/docker-airflow-two-test
-#  - us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade
-#  - us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade-test
+  - us.gcr.io/$PROJECT_ID/docker-airflow-two:${_IMAGE_TAG}
+  - us.gcr.io/$PROJECT_ID/docker-airflow-two-test:${_IMAGE_TAG}
+  - us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade:${_IMAGE_TAG}
+  - us.gcr.io/$PROJECT_ID/docker-airflow-two-upgrade-test:${_IMAGE_TAG}


### PR DESCRIPTION
Asana: https://app.asana.com/0/1206586586198682/1207787537237972/f

The images are building correctly now: https://console.cloud.google.com/cloud-build/builds;region=global/99ef8ac7-52d3-466e-9fd4-fcd7d793eef2?project=fathom-containers

Also, I checked the vulnerabilities. The old image (current `latest`) has 1074 vulnerabilities:
https://console.cloud.google.com/artifacts/docker/fathom-containers/us/us.gcr.io/docker-airflow-two-upgrade/sha256:b7453d1ae528a37a864638625af2e2983cd09be38ea0fdcd1e1a57505d7f8647;tab=vulnerabilities?project=fathom-containers

After my changes, there are 562 vulnerabilities:
https://console.cloud.google.com/artifacts/docker/fathom-containers/us/us.gcr.io/docker-airflow-two-upgrade/sha256:15ad40f31428ad52b7455f8db231b36c1e9e3693a7e74fe803227a23d80384cd;tab=vulnerabilities?project=fathom-containers

I ran a few D12s in a private airflow and they work fine (disregard the failed DAG, I accidentally started a non-D12 and failed it manually):
![Screenshot 2024-07-15 at 09 31 53](https://github.com/user-attachments/assets/c9ca82d7-f38f-4ee0-bb5a-cfa10a0d33de)

Airflow link: https://34.19.34.146:8080/home
`kube-config` changes used for testing: https://github.com/medicode/kube-config/commit/7ea85ebfc7806e6c28e25972bf52c87ee61b17ef