### PR TITLE
Add typing_extensions pip package

### DIFF
--- a/airflow_two/Dockerfile
+++ b/airflow_two/Dockerfile
@@ -92,6 +92,7 @@ RUN set -ex \
     && pip install google-cloud-logging==1.11.0 \
     && pip install retrying==1.3.3 \
     && pip install attrs==23.2.0 \
+    && pip install typing_extensions==4.7.1 \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \

--- a/airflow_two_upgrade/Dockerfile
+++ b/airflow_two_upgrade/Dockerfile
@@ -92,6 +92,7 @@ RUN set -ex \
     && pip install google-cloud-logging==1.11.0 \
     && pip install retrying==1.3.3 \
     && pip install attrs==23.2.0 \
+    && pip install typing_extensions==4.7.1 \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202694751236227/1207818614031580/f

The goal is to be able to import classes within code that runs inside the Airflow images that use `typing_extensions`. It now fails with `ImportError: cannot import name 'Self' from 'typing_extensions' (/usr/local/lib/python3.8/site-packages/typing_extensions.py)`: https://app.circleci.com/pipelines/github/medicode/diseaseTools/255220/workflows/1ef4f5cb-41f1-447f-a8a6-31b6d0fdea14/jobs/1391196