### PR TITLE
Add regex pip package

### DIFF
--- a/airflow_two/Dockerfile
+++ b/airflow_two/Dockerfile
@@ -93,6 +93,7 @@ RUN set -ex \
     && pip install retrying==1.3.3 \
     && pip install attrs==23.2.0 \
     && pip install typing_extensions==4.7.1 \
+    && pip install regex==2021.11.10 \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \

--- a/airflow_two_upgrade/Dockerfile
+++ b/airflow_two_upgrade/Dockerfile
@@ -93,6 +93,7 @@ RUN set -ex \
     && pip install retrying==1.3.3 \
     && pip install attrs==23.2.0 \
     && pip install typing_extensions==4.7.1 \
+    && pip install regex==2021.11.10 \
     && apt-get purge --auto-remove -yqq $buildDeps \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202694751236227/1207818614031580/f

The goal is to be able to import classes within code that runs inside the Airflow images that use `regex`. It now fails with `ModuleNotFoundError: No module named 'regex'`: https://app.circleci.com/pipelines/github/medicode/diseaseTools/255220/workflows/87ed71da-a0e6-467c-bec2-f0f42cb10885/jobs/1391339